### PR TITLE
Use put_char() when needed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ fn expand_msg(sev: Severity,
                         accumulator.push_str(s.get());
                     }
                     ast::LitChar(c) => {
-                        accumulator.push(c);
+                        accumulator.push_char(c);
                     }
                     ast::LitInt(i, ast::UnsignedIntLit(_)) |
                     ast::LitInt(i, ast::SignedIntLit(_, ast::Plus)) |


### PR DESCRIPTION
The current version fails to compile with rust-0.12.0
