### PR TITLE
Update for rustc 336349c93 2014-11-17 20:37:19 +0000

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ use syntax::ext::base;
 use syntax::ext::base::{ExtCtxt, DummyResult};
 use rustc::plugin::Registry;
 
+use Severity::{Note, Warning, Error, Fatal};
+
 enum Severity {
     Note,
     Warning,


### PR DESCRIPTION
I tried replacing `Error` by `Severity::Error`, but there seems to be some interop issues with macros (`macro doesn't expect token ::`), so I went for the reexports instead.
